### PR TITLE
Adding check for length of section name

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 	<div class="container">
 		<div class="pt-section" data-name="Sec One" id="ptsection-one"></div>
         <div class="pt-section" data-name="Sec Two" id="ptsection-two"></div>
-        <div class="pt-section" data-name="Sec Three" id="ptsection-three"></div>
+        <div class="pt-section" data-name="" id="ptsection-three"></div>
         <div class="pt-section" data-name="Sec Four" id="ptsection-four"></div>
 	</div>
 

--- a/static/js/jquery.progresstracker.js
+++ b/static/js/jquery.progresstracker.js
@@ -29,7 +29,8 @@
 			}
 
 			if(settings.tooltip) {
-				itemDescription = "<span class='pt-description'><span>" + sectionName + "</span></span>";
+                if(sectionName.length)
+    				itemDescription = "<span class='pt-description'><span>" + sectionName + "</span></span>";
 			}
 
 			$('.progress-tracker ul').append(


### PR DESCRIPTION
Code now checks if section name length is greater than zero, if not will not display popup element containing that text. This allows you to have some sections with names and some without, correcting a problem where if you tried this you still got an empty name label popup.
